### PR TITLE
fix: support uint8arrays as well as buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,12 @@
     "npm": ">=3.0.0"
   },
   "dependencies": {
-    "is-buffer": "^2.0.4",
     "varint": "^5.0.0"
   },
   "devDependencies": {
-    "aegir": "^21.9.0",
+    "aegir": "^25.0.0",
     "buffer": "^5.6.0",
-    "chai": "^4.2.0"
+    "uint8arrays": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
 'use strict'
 
 const varint = require('varint')
-const isBuffer = require('is-buffer')
 
 module.exports = (buf) => {
-  if (!isBuffer(buf)) {
-    throw new Error('arg needs to be a buffer')
+  if (!(buf instanceof Uint8Array)) {
+    throw new Error('arg needs to be a Uint8Array')
   }
 
   const result = []

--- a/test/varint-decoder.spec.js
+++ b/test/varint-decoder.spec.js
@@ -1,44 +1,55 @@
 /* eslint-env mocha */
 'use strict'
 
-const expect = require('chai').expect
+const { expect } = require('aegir/utils/chai')
 const { Buffer } = require('buffer')
+const uint8ArrayFromString = require('uint8arrays/from-string')
 const vd = require('../src')
 
-describe('varint-decoder', () => {
-  it('decode 1 varint', () => {
-    const buf = Buffer.from('05', 'hex')
-    const arr = vd(buf)
-    expect(arr[0]).to.equal(5)
-  })
+const types = [{
+  name: 'Buffer',
+  fromHexString: (hex) => Buffer.from(hex, 'hex')
+}, {
+  name: 'Uint8Array',
+  fromHexString: (hex) => uint8ArrayFromString(hex, 'base16')
+}]
 
-  it('decode 2 varints', () => {
-    const buf = Buffer.from('000a', 'hex')
-    const arr = vd(buf)
-    expect(arr[0]).to.equal(0)
-    expect(arr[1]).to.equal(10)
-  })
+types.forEach(({ name, fromHexString }) => {
+  describe(`varint-decoder (${name})`, () => {
+    it('decode 1 varint', () => {
+      const buf = fromHexString('05')
+      const arr = vd(buf)
+      expect(arr[0]).to.equal(5)
+    })
 
-  it('decode 3 varints', () => {
-    const buf = Buffer.from('0b0c03', 'hex')
-    const arr = vd(buf)
-    expect(arr[0]).to.equal(11)
-    expect(arr[1]).to.equal(12)
-    expect(arr[2]).to.equal(3)
-  })
+    it('decode 2 varints', () => {
+      const buf = fromHexString('000a')
+      const arr = vd(buf)
+      expect(arr[0]).to.equal(0)
+      expect(arr[1]).to.equal(10)
+    })
 
-  it('decode 1 long varint', () => {
-    const buf = Buffer.from('c801', 'hex')
-    const arr = vd(buf)
-    expect(arr[0]).to.equal(200)
-  })
+    it('decode 3 varints', () => {
+      const buf = fromHexString('0b0c03')
+      const arr = vd(buf)
+      expect(arr[0]).to.equal(11)
+      expect(arr[1]).to.equal(12)
+      expect(arr[2]).to.equal(3)
+    })
 
-  it('decode a mix of long and short', () => {
-    const buf = Buffer.from('96130208b90a', 'hex')
-    const arr = vd(buf)
-    expect(arr[0]).to.equal(2454)
-    expect(arr[1]).to.equal(2)
-    expect(arr[2]).to.equal(8)
-    expect(arr[3]).to.equal(1337)
+    it('decode 1 long varint', () => {
+      const buf = fromHexString('c801')
+      const arr = vd(buf)
+      expect(arr[0]).to.equal(200)
+    })
+
+    it('decode a mix of long and short', () => {
+      const buf = fromHexString('96130208b90a')
+      const arr = vd(buf)
+      expect(arr[0]).to.equal(2454)
+      expect(arr[1]).to.equal(2)
+      expect(arr[2]).to.equal(8)
+      expect(arr[3]).to.equal(1337)
+    })
   })
 })


### PR DESCRIPTION
Relaxes the input check to accept Uint8Arrays instead of node Buffers as this module doesn't do anything Buffer-specific.

Repeats the tests for both Buffers and Uint8Arrays.

Updates deps and removes ones that aren't used after the above refactor.